### PR TITLE
Old orders when updated sequential order numbers sequence breaks down.

### DIFF
--- a/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
+++ b/custom-order-numbers-for-woocommerce/includes/class-alg-wc-custom-order-numbers-core.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'Alg_WC_Custom_Order_Numbers_Core' ) ) :
 		 */
 		public function __construct() {
 			if ( 'yes' === get_option( 'alg_wc_custom_order_numbers_enabled', 'yes' ) ) {
-				add_action( 'wp_insert_post', array( $this, 'add_new_order_number' ), PHP_INT_MAX ); // 'woocommerce_new_order'
+				add_action( 'woocommerce_new_order', array( $this, 'add_new_order_number' ), PHP_INT_MAX );
 				add_filter( 'woocommerce_order_number', array( $this, 'display_order_number' ), PHP_INT_MAX, 2 );
 				if ( 'yes' === get_option( 'alg_wc_custom_order_numbers_order_tracking_enabled', 'yes' ) ) {
 					add_action( 'init', array( $this, 'alg_remove_tracking_filter' ) );


### PR DESCRIPTION
Old orders when updated sequential order numbers sequence breaks down. Also, the old order when updated it changes the order number of that order.  This is fixed now.

Fixes #22